### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,6 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-    actions:
-      patterns:
-        - "actions/*"
+      actions:
+        patterns:
+          - "actions/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    groups:
+    actions:
+      patterns:
+        - "actions/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This PR configures dependabot to 
- check for github-actions dependency updates on a monthly basis
- groups updates to actions beginning with "actions/" into the same PR

After merging this PR, we still need to enable _Dependabot version updates_ in Settings > Security > Code security and analysis. 
See also the dependabot [PRs](https://github.com/lochhh/aeon_docs/pulls) in the forked repo.