### PR TITLE
Configure dependabot to update submodules weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
       actions:
         patterns:
           - "actions/*"
+  - package-ecosystem: gitsubmodule
+    schedule:
+        interval: "weekly"
+    directory: "/"


### PR DESCRIPTION
With this configuration, dependabot will check weekly for new updates in submodules and open a PR for each submodule that has newer commits. 