### PR TITLE
Mimic autosummary tables for Aeon.Acquisition API

### DIFF
--- a/make_acquisition_doctree.py
+++ b/make_acquisition_doctree.py
@@ -4,93 +4,122 @@ from pathlib import Path
 import yaml
 
 
+def run_docfx_metadata(src_path: Path, output_format: str = "markdown"):
+    """
+    Run docfx metadata command to generate YAML files from source code.
+    """
+    subprocess.run(
+        ["dotnet", "docfx", "metadata", "--outputFormat", f"{output_format}"],
+        cwd=src_path,
+    )
+
+
+def rewrite_section(section: str):
+    """
+    Rewrite a single section of a namespace document as a list-table.
+    """
+    section_title, section_body = section.split("\n\n", 1)
+    section_content = (
+        f":::{{rubric}}{section_title}\n:::"
+        "\n\n::: {list-table}\n:class: acquisition-api-table\n\n"
+    )
+    section_lines = section_body.split("\n\n")
+    # Remove empty lines
+    section_lines = [line for line in section_lines if line.strip()]
+    # Check if description column is required
+    has_description = any([not line.startswith(" [") for line in section_lines])
+    for idx, section_line in enumerate(section_lines):
+        is_description = not section_line.startswith(" [")
+        if is_description:
+            # Description column
+            section_content += f"    - {section_line}\n"
+        else:
+            # Extract link text and URL
+            link_text = section_line.split("[")[1].split("]")[0]
+            link_path = section_line.split("(")[1].split(")")[0]
+            # Reconstruct the link with backticks
+            section_line = f"[`{link_text}`]({link_path})"
+            section_content += f"*   - {section_line}\n"
+        if not has_description:  # Single column table
+            continue
+        # Check if next line is a description line
+        try:
+            next_line = section_lines[idx + 1]
+            if next_line.startswith(" [") and not is_description:
+                # Account for empty description
+                section_content += "    - \n"
+        except IndexError:  # Last line
+            if not is_description:
+                section_content += "    - \n"
+    section_content += ":::\n\n"
+    return section_content
+
+
+def process_namespace(namespace: dict, metadata_path: Path):
+    """
+    Process a single namespace from the toc file.
+
+    Specifically, this function returns a table row and a toctree entry
+    for the namespace on the main page.
+    It also rewrites the namespace document and adds a toctree to it.
+    """
+    namespace_name = namespace["name"]
+    namespace_href = namespace.get("href")
+    namespace_items = namespace.get("items")
+    if namespace_href is None or namespace_items is None:
+        return None, None
+    # Generate entry to table on main page that mimics aeon_mecha doc structure
+    table_row = f"*   - [``{namespace_name}``](acquisition/{namespace_name})\n"
+    # Generate toctree entry
+    toctree_entry = f"    {namespace_name} <acquisition/{namespace_name}>\n"
+    # Generate toctree for namespace document
+    namespace_path = metadata_path.joinpath(namespace_href)
+    with open(namespace_path, "r+", encoding="utf-8") as nsf:
+        content = nsf.read()
+        sections = content.split("###")
+        content = sections[0]  # Page header
+        for section in sections[1:]:
+            content += rewrite_section(section)
+        content += ":::{toctree}\n   :hidden:\n"
+        # loop through all namespace items
+        for item in namespace_items:
+            item_name = item["name"]
+            item_href = item.get("href")
+            if item_href is None:  # item is category, skip for now
+                continue
+            # item is type, add toctree entry
+            item_path = metadata_path.joinpath(item_href)
+            item_filename = item_path.with_suffix("").name
+            content += f"\n{item_name} <{item_filename}>"
+        content += "\n:::"
+        nsf.seek(0)
+        nsf.write(content)
+        nsf.truncate()
+    return table_row, toctree_entry
+
+
 def make_acquisition_doctree():
     """
     Create a doctree of all namespaces in aeon_acquisition.
     """
+    # Generate .md API files from source code
     src_path = Path("src")
-    subprocess.run(
-        ["dotnet", "docfx", "metadata", "--outputFormat", "markdown"], cwd=src_path
-    )
+    run_docfx_metadata(src_path)
+    # Path to main page (src/reference/api/acquisition.md)
     metadata_path = src_path.joinpath("reference", "api", "acquisition")
     # Get acquisition toc
-    with open(metadata_path.joinpath("toc.yml"), "r") as f:
-        acquisition_toc = yaml.safe_load(f)
-    # Initialise content for main page
-    api_head = (
-        "<!-- This file is auto-generated. -->\n\n"
-        "(target-acquisition-reference)="
-        "\n# ``aeon_acquisition``\n\n"
-    )
+    acquisition_toc = yaml.safe_load(metadata_path.joinpath("toc.yml").read_text())
+    # Get the main page header
+    api_head_path = Path("src") / "_templates" / "api_acquisition_head.md"
+    api_head = api_head_path.read_text()
+    # Initialise sections
     table_rows = ":::{list-table}\n:class: acquisition-api-table\n\n"
     toctree = ":::\n\n:::{toctree}\n    :glob:\n    :hidden:\n\n"
     # All namespaces are children of the root element
     for namespace in acquisition_toc:
-        namespace_name = namespace["name"]
-        namespace_href = namespace.get("href")
-        namespace_items = namespace.get("items")
-        if namespace_href is None or namespace_items is None:
-            continue
-        # Add toc entry to table on main page to mimic aeon_mecha doc structure
-        table_rows += f"*   - [``{namespace_name}``](acquisition/{namespace_name})\n"
-        # Add namespace toctree entry
-        toctree += f"    {namespace_name} <acquisition/{namespace_name}>\n"
-        # Generate toctree for each namespace document
-        namespace_path = metadata_path.joinpath(namespace_href)
-        with open(namespace_path, "r+", encoding="utf-8") as nsf:
-            content = nsf.read()
-            sections = content.split("###")
-            content = sections[0]
-            for section in sections[1:]:
-                section_title, section_body = section.split("\n\n", 1)
-                section_content = f":::{{rubric}}{section_title}\n:::\n\n::: {{list-table}}\n:class: acquisition-api-table\n\n"
-                section_lines = section_body.split("\n\n")
-                # Remove empty lines
-                section_lines = [line for line in section_lines if line.strip()]
-                # Check if description column is required
-                has_description = any(
-                    [not line.startswith(" [") for line in section_lines]
-                )
-                for idx, section_line in enumerate(section_lines):
-                    is_description = not section_line.startswith(" [")
-                    if is_description:
-                        # Description column
-                        section_content += f"    - {section_line}\n"
-                    else:
-                        # Extract link text and URL
-                        link_text = section_line.split("[")[1].split("]")[0]
-                        link_path = section_line.split("(")[1].split(")")[0]
-                        # Reconstruct the link with backticks
-                        section_line = f"[`{link_text}`]({link_path})"
-                        section_content += f"*   - {section_line}\n"
-                    if not has_description:  # Single column table
-                        continue
-                    # Check if next line is a description line
-                    try:
-                        next_line = section_lines[idx + 1]
-                        if next_line.startswith(" [") and not is_description:
-                            # Account for empty description
-                            section_content += "    - \n"
-                    except IndexError:  # Last line
-                        if not is_description:
-                            section_content += "    - \n"
-                section_content += ":::\n\n"
-                content += section_content
-            content += ":::{toctree}\n   :hidden:\n"
-            # loop through all namespace items
-            for item in namespace_items:
-                item_name = item["name"]
-                item_href = item.get("href")
-                if item_href is None:  # item is category, skip for now
-                    continue
-                # item is type, add toctree entry
-                item_path = metadata_path.joinpath(item_href)
-                item_filename = item_path.with_suffix("").name
-                content += f"\n{item_name} <{item_filename}>"
-            content += "\n:::"
-            nsf.seek(0)
-            nsf.write(content)
-            nsf.truncate()
+        table_row, toctree_entry = process_namespace(namespace, metadata_path)
+        table_rows += table_row
+        toctree += toctree_entry
     toctree += "\n:::"
     with open(metadata_path.with_suffix(".md"), "w") as f:
         f.write(api_head + table_rows + toctree)

--- a/make_acquisition_doctree.py
+++ b/make_acquisition_doctree.py
@@ -1,6 +1,7 @@
-import yaml
 import subprocess
 from pathlib import Path
+
+import yaml
 
 
 def make_acquisition_doctree():
@@ -8,55 +9,91 @@ def make_acquisition_doctree():
     Create a doctree of all namespaces in aeon_acquisition.
     """
     src_path = Path("src")
-    subprocess.run(["dotnet", "docfx", "metadata", "--outputFormat", "markdown"], cwd=src_path)
+    subprocess.run(
+        ["dotnet", "docfx", "metadata", "--outputFormat", "markdown"], cwd=src_path
+    )
     metadata_path = src_path.joinpath("reference", "api", "acquisition")
-
-    # get the acquisition doc header
+    # Get acquisition toc
     with open(metadata_path.joinpath("toc.yml"), "r") as f:
         acquisition_toc = yaml.safe_load(f)
-
-    # write file for acquisition doc with header + doctree
-    with open(metadata_path.with_suffix(".rst"), "w") as f:
-        f.write("..\n  This file is auto-generated.\n\n")
-        f.write(".. _target-acquisition-reference:\n\n")
-        f.write("``aeon_acquisition``\n")
-        f.write("=====================\n\n")
-        f.write(".. toctree::\n")
-        f.write("    :glob:\n\n")
-
-        # all namespaces are children of the root element
-        for namespace in acquisition_toc:
-            namespace_name = namespace["name"]
-            namespace_href = namespace.get("href")
-            namespace_items = namespace.get("items")
-            if namespace_href is None or namespace_items is None:
-                continue
-
-            # add namespace toctree entry
-            f.write(f"    {namespace_name} <acquisition/{namespace_name}>\n")
-
-            # generate toctree for each namespace document
-            namespace_path = metadata_path.joinpath(namespace_href)
-            with open(namespace_path, "r+", encoding="utf-8") as nsf:
-                content = nsf.read()
-                content += "```{toctree}\n"
-
-                # loop through all namespace items
-                for item in namespace_items:
-                    item_name = item["name"]
-                    item_href = item.get("href")
-                    if item_href is None:  # item is category, skip for now
+    # Initialise content for main page
+    api_head = (
+        "<!-- This file is auto-generated. -->\n\n"
+        "(target-acquisition-reference)="
+        "\n# ``aeon_acquisition``\n\n"
+    )
+    table_rows = ":::{list-table}\n:class: acquisition-api-table\n\n"
+    toctree = ":::\n\n:::{toctree}\n    :glob:\n    :hidden:\n\n"
+    # All namespaces are children of the root element
+    for namespace in acquisition_toc:
+        namespace_name = namespace["name"]
+        namespace_href = namespace.get("href")
+        namespace_items = namespace.get("items")
+        if namespace_href is None or namespace_items is None:
+            continue
+        # Add toc entry to table on main page to mimic aeon_mecha doc structure
+        table_rows += f"*   - [``{namespace_name}``](acquisition/{namespace_name})\n"
+        # Add namespace toctree entry
+        toctree += f"    {namespace_name} <acquisition/{namespace_name}>\n"
+        # Generate toctree for each namespace document
+        namespace_path = metadata_path.joinpath(namespace_href)
+        with open(namespace_path, "r+", encoding="utf-8") as nsf:
+            content = nsf.read()
+            sections = content.split("###")
+            content = sections[0]
+            for section in sections[1:]:
+                section_title, section_body = section.split("\n\n", 1)
+                section_content = f":::{{rubric}}{section_title}\n:::\n\n::: {{list-table}}\n:class: acquisition-api-table\n\n"
+                section_lines = section_body.split("\n\n")
+                # Remove empty lines
+                section_lines = [line for line in section_lines if line.strip()]
+                # Check if description column is required
+                has_description = any(
+                    [not line.startswith(" [") for line in section_lines]
+                )
+                for idx, section_line in enumerate(section_lines):
+                    is_description = not section_line.startswith(" [")
+                    if is_description:
+                        # Description column
+                        section_content += f"    - {section_line}\n"
+                    else:
+                        # Extract link text and URL
+                        link_text = section_line.split("[")[1].split("]")[0]
+                        link_path = section_line.split("(")[1].split(")")[0]
+                        # Reconstruct the link with backticks
+                        section_line = f"[`{link_text}`]({link_path})"
+                        section_content += f"*   - {section_line}\n"
+                    if not has_description:  # Single column table
                         continue
-
-                    # item is type, add toctree entry
-                    item_path = metadata_path.joinpath(item_href)
-                    item_filename = item_path.with_suffix("").name
-                    content += f"\n{item_name} <{item_filename}>"
-
-                content += "\n```"
-                nsf.seek(0)
-                nsf.write(content)
-                nsf.truncate()
+                    # Check if next line is a description line
+                    try:
+                        next_line = section_lines[idx + 1]
+                        if next_line.startswith(" [") and not is_description:
+                            # Account for empty description
+                            section_content += "    - \n"
+                    except IndexError:  # Last line
+                        if not is_description:
+                            section_content += "    - \n"
+                section_content += ":::\n\n"
+                content += section_content
+            content += ":::{toctree}\n   :hidden:\n"
+            # loop through all namespace items
+            for item in namespace_items:
+                item_name = item["name"]
+                item_href = item.get("href")
+                if item_href is None:  # item is category, skip for now
+                    continue
+                # item is type, add toctree entry
+                item_path = metadata_path.joinpath(item_href)
+                item_filename = item_path.with_suffix("").name
+                content += f"\n{item_name} <{item_filename}>"
+            content += "\n:::"
+            nsf.seek(0)
+            nsf.write(content)
+            nsf.truncate()
+    toctree += "\n:::"
+    with open(metadata_path.with_suffix(".md"), "w") as f:
+        f.write(api_head + table_rows + toctree)
 
 
 if __name__ == "__main__":

--- a/src/_static/css/custom.css
+++ b/src/_static/css/custom.css
@@ -42,3 +42,7 @@ html[data-theme=light] {
 .sd-img-bottom-small {
   height: 8vw; 
 }
+
+.acquisition-api-table code {
+  color: var(--pst-color-inline-code-links);
+}

--- a/src/_templates/api_acquisition_head.md
+++ b/src/_templates/api_acquisition_head.md
@@ -1,0 +1,5 @@
+<!-- This file is auto-generated. -->
+
+(target-acquisition-reference)=
+# ``aeon_acquisition``
+

--- a/src/conf.py
+++ b/src/conf.py
@@ -105,6 +105,9 @@ autodoc_default_options = {
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_templates"]
 
+# Suppress warnings for non-consecutive header level
+suppress_warnings = ["myst.header"]
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
This PR tries to achieve a consistent look in the summary page for both [aeon_mecha](https://sainsburywellcomecentre.github.io/aeon_docs/reference/api/mecha.html) and [aeon_acquisition](https://sainsburywellcomecentre.github.io/aeon_docs/reference/api/acquisition.html). 
It does so by rewriting the docfx-generated `.md` files in `make_acquisition_doctree.py`.

Main "summary" page for Aeon.Acquisition
![image](https://github.com/user-attachments/assets/f62ffe52-f18c-48aa-b2ae-787f3192b31d)
and for each namespace:
![image](https://github.com/user-attachments/assets/76189fd5-7980-4279-bda9-d2ae42af6e77)
    