### PR TITLE
Add xrefs to docfx.json

### DIFF
--- a/src/docfx.json
+++ b/src/docfx.json
@@ -29,13 +29,14 @@
         ]
       }
     ],
-
     "xref": [
       "https://horizongir.github.io/opencv.net/xrefmap.yml",
       "https://horizongir.github.io/ZedGraph/xrefmap.yml",
       "https://horizongir.github.io/opentk/xrefmap.yml",
       "https://horizongir.github.io/reactive/xrefmap.yml",
-      "https://bonsai-rx.org/sleap/xrefmap.yml"
+      "https://bonsai-rx.org/sleap/xrefmap.yml",
+      "https://bonsai-rx.org/docs/xrefmap.yml",
+      "https://harp-tech.org/xrefmap.yml"
     ]
   }
 }


### PR DESCRIPTION
This PR adds a few xrefs for DocFX, but the `xref` argument is not currently used since the .md files are generated using `docfx metadata` instead of `docfx build` where the `xref` argument is applied (see [previous conversation](https://github.com/SainsburyWellcomeCentre/aeon_docs/pull/103#pullrequestreview-2593329493)). 
 I can't find any xrefmap files for [mathdotnet](https://numerics.mathdotnet.com/api/) and [mysqlconnector](https://mysqlconnector.net/api) though. 