### PR TITLE
Update documentation links to reflect new Aeon URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,12 @@
 # aeon_docs
 
-This repo contains the source for the [Aeon online documentation](https://sainsburywellcomecentre.github.io/aeon_docs/). 
+This repo contains the source for the [Aeon online documentation](https://aeon.swc.ucl.ac.uk). 
 
 > [!CAUTION] 
 > The documentation is currently under active development and may be incomplete.
 > Please report any issues or suggestions for improvement by [opening an issue](https://github.com/SainsburyWellcomeCentre/aeon_docs/issues).
 
-To contribute to the documentation, please see the [Contributor Guide](https://sainsburywellcomecentre.github.io/aeon_docs/contributor/index.html).
+To contribute to the documentation, please see the [Contributor Guide](https://aeon.swc.ucl.ac.uk/contributor/index.html).
 
 ## Aeon organisation overview
 

--- a/src/conf.py
+++ b/src/conf.py
@@ -152,9 +152,10 @@ html_js_files = [
 
 # linkcheck will skip checking these URLs entirely
 linkcheck_ignore = [
-    r"https://liveuclac\.sharepoint\.com/.*",  # UCL internal SharePoint
-    r"http://SubjectExpressionBuilder\.Name",  # Broken URL
-    r"https://learn\.microsoft\.com/dotnet/api/.*",  # 429 Client Error: Too Many Requests for url
+    "https://liveuclac.sharepoint.com/",  # UCL internal SharePoint
+    "http://SubjectExpressionBuilder.Name",  # Broken URL
+    "https://learn.microsoft.com/dotnet/api/",  # 429 Client Error: Too Many Requests for url
+    "https://www.sainsburywellcome.org/",  # Occasional ConnectTimeoutError
 ]
 
 # linkcheck will treat redirections from these source URI:canonical URI

--- a/src/conf.py
+++ b/src/conf.py
@@ -169,7 +169,7 @@ myst_url_schemes = {
     "https": None,
     "ftp": None,
     "mailto": None,
-    "aeon-docs": "https://sainsburywellcomecentre.github.io/aeon_docs/{{path}}",
+    "aeon-docs": "https://aeon.swc.ucl.ac.uk/{{path}}",
     "aeon-docs-github": "https://github.com/SainsburyWellcomeCentre/aeon_docs/{{path}}",
     "aeon-mecha-github": "https://github.com/SainsburyWellcomeCentre/aeon_mecha/{{path}}",
     "aeon-acquisition-github": "https://github.com/SainsburyWellcomeCentre/aeon_acquisition/{{path}}",

--- a/src/contributor/contributing_documentation.md
+++ b/src/contributor/contributing_documentation.md
@@ -1,7 +1,7 @@
 (target-contributing-documentation)=
 # Contributing Documentation
 The documentation is built via [Sphinx](https://www.sphinx-doc.org/en/master/), 
-and hosted via GitHub Pages at [sainsburywellcomecentre.github.io/aeon_docs/](aeon-docs:). 
+and hosted at [aeon.swc.ucl.ac.uk](aeon-docs:). 
 `src/` is the Sphinx source directory, where you can find the Markdown (`.md`) and RestructuredText (`.rst`) files that make up the documentation. 
 The site is built and deployed from the `gh-pages` branch. 
 This is handled by a GitHub actions workflow (`.github/workflows/docs_build_and_deploy.yml`), triggered by the following events:


### PR DESCRIPTION
This PR replaces all occurrences of `sainsburywellcomecentre.github.io/aeon_docs/` with `aeon.swc.ucl.ac.uk`.