### PR TITLE
Restrict deploy_sphinx_docs to `main` branch on manual workflow dispatch

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -2,9 +2,10 @@ name: Docs
 
 # Generate the documentation on all merges to main, all pull requests, or by
 # manual workflow dispatch. The build job can be used as a CI check that the
-# docs still build successfully. The deploy job only runs (1) when a tag is
-# pushed or (2) on manual workflow dispatch. This will move the generated html
-# to the gh-pages branch (which triggers a GitHub pages deployment).
+# docs still build successfully. The deploy job which moves the generated
+# html to the gh-apges branch and triggers a GitHub pages deployment
+# only runs when a tag is pushed or when the workflow is manually dispatched
+# from the main branch.
 on:
   push:
     branches:
@@ -79,7 +80,9 @@ jobs:
     needs: build_sphinx_docs
     permissions:
       contents: write
-    if: (github.event_name == 'push' && github.ref_type == 'tag') || github.event_name == 'workflow_dispatch'
+    if: |
+      (github.event_name == 'push' && github.ref_type == 'tag') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Closes #127 
Tested on [fork](https://github.com/lochhh/aeon_docs/actions/runs/16074242789): `deploy_sphinx_docs` is skipped when the docs workflow is triggered manually on a non-`main` branch