### PR TITLE
Update permanently redirected URLs and `linkcheck` ignore list

### DIFF
--- a/src/_templates/footer_end.html
+++ b/src/_templates/footer_end.html
@@ -19,7 +19,7 @@
         <img src="{{ pathto('_static/images/light-logo-ucl.png', 1) }}" alt="Sponsors" class="only-light img-sponsor"/>
         <img src="{{ pathto('_static/images/dark-logo-ucl.png', 1) }}" alt="Sponsors" class="only-dark img-sponsor"/>
     </a>
-    <a href="https://www.ucl.ac.uk/gatsby/gatsby-computational-neuroscience-unit">
+    <a href="https://www.ucl.ac.uk/life-sciences/gatsby">
         <img src="{{ pathto('_static/images/light-logo-gatsby.png', 1) }}" alt="Sponsors" class="only-light img-sponsor"/>
         <img src="{{ pathto('_static/images/dark-logo-gatsby.png', 1) }}" alt="Sponsors" class="only-dark img-sponsor"/>
     </a>

--- a/src/about/index.md
+++ b/src/about/index.md
@@ -1,7 +1,7 @@
 (target-about)=
 # About
 
-The development of Aeon is funded by the [Gatsby Charitable Foundation](https://www.gatsby.org.uk/) and [Wellcome](https://wellcome.org/). This joint initiative involves people from the [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/) and the [Gatsby Computational Neuroscience Unit](https://www.ucl.ac.uk/gatsby/gatsby-computational-neuroscience-unit) at UCL, [NeuroGEARS Ltd](https://neurogears.org/), and [DataJoint Inc](datajoint:). For a full list of people involved, please refer to this [page](target-people).
+The development of Aeon is funded by the [Gatsby Charitable Foundation](https://www.gatsby.org.uk/) and [Wellcome](https://wellcome.org/). This joint initiative involves people from the [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/) and the [Gatsby Computational Neuroscience Unit](https://www.ucl.ac.uk/life-sciences/gatsby) at UCL, [NeuroGEARS Ltd](https://neurogears.org/), and [DataJoint Inc](datajoint:). For a full list of people involved, please refer to this [page](target-people).
 
 The brain's computations are shaped by evolutionary pressures related to survival and the resulting behavioural responses. 
 Understanding the neural basis of natural behaviours is crucial for advancing our knowledge of the brain, as it sheds light on the functions of neural circuits in processing real-world stimuli. 

--- a/src/conf.py
+++ b/src/conf.py
@@ -159,6 +159,7 @@ linkcheck_ignore = [
     "https://www.sainsburywellcome.org/",  # Occasional ConnectTimeoutError
     "https://doi.org/10.1101/2025.07.31.664513",  # 403 Client Error: Forbidden for bioRxiv url
     "https://www.biorxiv.org/content/10.1101/2025.07.31.664513",  # 403 Client Error: Forbidden for bioRxiv url
+    r"globus\.org",  # All URLs containing globus.org
     r"(?:\.\./)+_images/.*",  # Internal image references that get remapped during build
 ]
 


### PR DESCRIPTION
- skip linkchecks for globus.org
- update permanently redirected Gatsby URLs