### PR TITLE
Fetch tags upon checkout in docs build workflow

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true # Enable automatic checkout of all submodules
+          fetch-tags: true # For determining the latest tag in conf.py
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5


### PR DESCRIPTION
The actions/checkout step does not specify fetch-depth, so it defaults to 1 (a shallow clone with only the latest commit but no tags). In conf.py `git describe --tags --abbrev=0` then fails to find any tag and returns "".