### PR TITLE
Improve SVG rendering in light and dark mode

### DIFF
--- a/src/_static/css/custom.css
+++ b/src/_static/css/custom.css
@@ -61,6 +61,18 @@ html[data-theme=light] {
 /* ==========================
    4. Image Styles
    ========================== */
+
+/* Invert SVG line art in dark mode */
+/* screen blend removes the inverted black bg */
+html[data-theme=dark] img[src$=".svg"] {
+  filter: invert(1) hue-rotate(180deg);
+  mix-blend-mode: screen;
+}
+
+/* Hover needs a bg so mix-blend-mode: screen can blend */
+html[data-theme=dark] .sd-card-hover:hover {
+  background-color: var(--pst-color-background);
+}
 .sd-card-img-bottom {
   object-fit: contain;
   padding: 1rem !important;

--- a/src/_static/css/custom.css
+++ b/src/_static/css/custom.css
@@ -62,6 +62,11 @@ html[data-theme=light] {
    4. Image Styles
    ========================== */
 
+/* Remove white bg in SVG to match surrounding div in light mode */
+html[data-theme=light] img[src$=".svg"] {
+  mix-blend-mode: multiply;
+}
+
 /* Invert SVG line art in dark mode */
 /* screen blend removes the inverted black bg */
 html[data-theme=dark] img[src$=".svg"] {

--- a/src/_static/css/custom.css
+++ b/src/_static/css/custom.css
@@ -83,7 +83,7 @@ html[data-theme=light] {
 }
 
 img.img-hardware-steps {
-  max-height: 40vh;
+  width: 100%;
 }
 
 img.img-hardware-main {


### PR DESCRIPTION
Closes #119 and #208 

- SVGs with line art (transparent/white background, black/coloured lines) rendered with visible white boxes in both light and dark mode.
  - In light mode: mix-blend-mode: multiply removes the baked-in white background so SVGs blend into the surrounding div.
  - In dark mode: filter: invert(1) hue-rotate(180deg) turns black lines white; mix-blend-mode: screen dissolves the inverted black background. A background fix on .sd-card-hover:hover prevents the blend from breaking when card hover triggers an isolated stacking context via transform: scale.
- Changed hardware step images from max-height: 40vh to width: 100% for consistent full-width display.