### PR TITLE
Strip inline HTML from prev/next titles

### DIFF
--- a/src/_templates/components/prev-next.html
+++ b/src/_templates/components/prev-next.html
@@ -1,0 +1,25 @@
+{# Displays links to the previous and next page in the TOCtree order. #}
+<div class="prev-next-area">
+  {%- if prev %}
+    <a class="left-prev"
+       href="{{ prev.link|e }}"
+       title="{{ _('previous page') }}">
+      <i class="fa-solid fa-angle-left"></i>
+      <div class="prev-next-info">
+        <p class="prev-next-subtitle">{{ _("previous") }}</p>
+        <p class="prev-next-title">{{ (prev_title or prev.title)|striptags }}</p>
+      </div>
+    </a>
+  {%- endif %}
+  {%- if next %}
+    <a class="right-next"
+       href="{{ next.link|e }}"
+       title="{{ _('next page') }}">
+      <div class="prev-next-info">
+        <p class="prev-next-subtitle">{{ _("next") }}</p>
+        <p class="prev-next-title">{{ (next_title or next.title)|striptags }}</p>
+      </div>
+      <i class="fa-solid fa-angle-right"></i>
+    </a>
+  {%- endif %}
+</div>


### PR DESCRIPTION
Closes #251 

- overrides `pydata-sphinx-theme`'s [components/prev-next.html](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html#built-in-components-to-insert-into-sections) template to use Jinja2 [`striptags` filter](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.striptags). This change only affects `aeon_acquisition` API reference.
